### PR TITLE
Update install.bat - Invoke-WebRequest command fails with a DirectoryNotFoundException error.

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -125,6 +125,7 @@ if .ERRORLEVEL. neq 0 (
 )
 
 echo Downloading latest model
+md models
 powershell -Command "Invoke-WebRequest -Uri 'https://the-eye.eu/public/AI/models/nomic-ai/gpt4all/gpt4all-lora-quantized-ggml.bin' -OutFile 'models/gpt4all-lora-quantized-ggml.bin'"
 
 echo Cleaning tmp folder


### PR DESCRIPTION
The current code assumes that the models directory exists, but this may not always be the case. If the models directory does not exist, the Invoke-WebRequest command fails with a DirectoryNotFoundException error.