### PR TITLE
Resolved installation error

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -118,7 +118,7 @@ REM Install the required packages
 echo Installing requirements ...
 python -m pip install pip --upgrade
 python -m pip install -r requirements.txt
-if .ERRORLEVEL. neq 0 (
+if %ERRORLEVEL% neq 0 (
     echo Failed to install required packages. Please check your internet connection and try again.
     pause
     exit /b 1


### PR DESCRIPTION
Changed to "%ERRORLEVEL%" because ".ERRORLEVEL." is not a valid syntax, this should fix the "Failed to install required packages. Please check your internet connection and try again. Press any key to continue . . ." error despite the requirements being installed correctly.