### PR TITLE
Fix "ModuleNotFoundError: No module named 'db'" bug when running docker-compose up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN python3 -m venv venv && . venv/bin/activate
 RUN python3 -m pip install --no-cache-dir -r requirements.txt --upgrade pip
 
 COPY ./app.py /srv/app.py
+#COPY ./db.py /srv/db.py
 COPY ./static /srv/static
 COPY ./templates /srv/templates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN python3 -m venv venv && . venv/bin/activate
 RUN python3 -m pip install --no-cache-dir -r requirements.txt --upgrade pip
 
 COPY ./app.py /srv/app.py
-#COPY ./db.py /srv/db.py
+COPY ./db.py /srv/db.py
 COPY ./static /srv/static
 COPY ./templates /srv/templates
 


### PR DESCRIPTION
## Issue
`db` module is not imported into Docker image when building docker image. This results in not found `db` module during running with `docker-compose up`

```
gpt4old-webui-1  | Traceback (most recent call last):
gpt4old-webui-1  |   File "/srv/app.py", line 8, in <module>
gpt4old-webui-1  |     from db import Discussion, export_to_json, check_discussion_db, last_discussion_has_messages
gpt4old-webui-1  | ModuleNotFoundError: No module named 'db'
gpt4old-webui-1 exited with code 1
```

## Steps to Reproduce

1. Run `git clone https://github.com/nomic-ai/gpt4all-ui/`
2. Download and copy model to `models` folder
3. Run `docker compose up`
    _(equivalent to `docker-compose -f docker-compose.yml build` then `docker-compose -f docker-compose.yml up` as in README.md#docker-compose-setup instructions)_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested this code locally, and it is working as intended