### PR TITLE
Update websocket.js to use browser scheme

### DIFF
--- a/static/js/websocket.js
+++ b/static/js/websocket.js
@@ -14,7 +14,7 @@ var globals={
     waitAnimation:undefined
 }
   
-var socket = io.connect('http://' + document.domain + ':' + location.port);
+var socket = io.connect(location.protocol + '//' + document.domain + ':' + location.port);
 
 socket.on('connect', function() {
 });


### PR DESCRIPTION
## Description

Change websocket.js to use the browser's scheme. I run gpt4all behind a HTTPS proxy which makes causes mixed content errors.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Please put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested this code locally, and it is working as intended
- [ ] I have updated the documentation accordingly

## Screenshots
If applicable, add screenshots to help explain your changes.
